### PR TITLE
Add book and mailing list to list of ruby resources

### DIFF
--- a/programming_languages/ruby.md
+++ b/programming_languages/ruby.md
@@ -5,9 +5,10 @@ Ruby
 
 - The Well-Grounded Rubyist, David Black - http://amzn.com/1617291692
 - Eloquent Ruby, Russ Olsen - http://amzn.com/0321584104
+- Learn to Program, 2nd Edition (The facets of Ruby series), Chris Pine - http:/amzn.com/1934356360
 
 *Other resources:*
 
-- Mailing list -
+- Mailing list - ruby-talk@ruby-lang.org
 - IRC channel -
 - Weekly newsletter - Ruby Weekly - http://rubyweekly.com/


### PR DESCRIPTION
Changes:
- Add book Learn to Program by Chris Pine
- Add ruby talk mailing list which talks about general topics about Ruby
  and is the most popular mailing list according to:
  https://www.ruby-lang.org/en/community/mailing-lists/
